### PR TITLE
Removed restriction for node pattern right-hand sides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.csv
+*.facts
+*.cpp

--- a/bb-grin-hpt-2.dl
+++ b/bb-grin-hpt-2.dl
@@ -1,0 +1,358 @@
+// heap points-to analysis for grin with basic blocks
+/*
+  OLD GRIN PROBLEMS:
+    bind pattern naming
+      WORKAROUND: '(CInt r)' identifies the 'pure v3' instruction
+
+    case alternative nameing / Basic Block naming
+      WORKAROUND: Basic Block name can be constructed e.g. case identifier 'h' + alternative identifier '(CInt x)' so the Basic Block's name would be 'h:(CInt x)'
+
+  IDEALLY:
+    case alternatives would call Basic Blocks
+    @-pattern for bind patterns and case patterns
+
+  APPROACH:
+    define a new AST for the improved GRIN with conversion function to/from the current GRIN AST
+*/
+
+
+/*
+grinMain =
+  c0 <- pure 1
+  c1 <- pure 12
+
+  v1 <- pure (CInt c0)
+  t1 <- store v1
+  v2 <- pure (CInt c1)
+  t2 <- store v2
+  v3 <- eval t2
+  p1@(CInt r) <- pure v3
+  v4 <-_prim_int_print r
+  pure v4
+
+eval q = v <- fetch q
+         h <- case v of
+          p2@(CInt x) -> BB0 x
+          p3          -> BB1 p3
+         BB0 y = pure v
+         BB1 y2 = pure y2
+         pure h
+*/
+
+.type BasicBlock
+.type Function
+.type Variable
+.type Tag
+.type Literal
+.type LiteralType
+.type CodeName = BasicBlock | Function
+
+// variable
+// example: result <- pure value
+.decl Move(result:Variable, value:Variable)
+
+// literal value
+// example: result <- pure 1
+//.decl LitAssign(result:Variable, l:Literal, lt:LiteralType)
+/*
+  literals can be modeled with nodes where node tag describes the literal type and node argument stores the literal value
+*/
+
+
+// node value
+// example: result_node <- pure (Ctag item0 item1)
+.decl Node(result_node:Variable, t:Tag)
+.decl NodeArgument(result_node:Variable, i:number, item:Variable)
+// store/fetch/update
+// example: result <- fetch value
+.decl Fetch(result:Variable, value:Variable)
+.decl Store(result:Variable, value:Variable)
+// example: result <- update target value
+.decl Update(result:Variable, target:Variable, value:Variable)
+// app a.k.a. call
+// example: call_result <- f value0 value1
+.decl Call(call_result:Variable, f:Function)
+.decl CallArgument(call_result:Variable, i:number, value:Variable)
+// bind pattern
+// example: node@(Ctag param0 param1) <- pure input_value
+.decl NodePattern(node:Variable, t:Tag, input_value:Variable)
+.decl NodeParameter(node:Variable, i:number, parameter:Variable)
+// function
+// example: f param0 param1 = ...
+.decl FunctionParameter(f:Function, i:number, parameter:Variable)
+// case + alt
+// example:
+//  case_result <- case scrut of
+//    alt_value@(Ctag param0 param1) -> basic_block_name arg0 arg1
+.decl Case(case_result:Variable, scrutinee:Variable)
+.decl Alt(case_result:Variable, alt_value:Variable, t:Tag, b:BasicBlock)
+.decl AltParameter(alt_value:Variable, i:number, parameter:Variable)
+.decl AltArgument(alt_value:Variable, i:number, value:Variable)
+// basic block
+// example: bb param0 param1 = ...
+.decl BlockParameter(b:BasicBlock, i:number, parameter:Variable)
+// pure a.k.a. return value
+// example: pure value
+.decl ReturnValue(n:CodeName, value:Variable)
+
+// instruction ordering
+.decl FirstInst(n:CodeName, result:Variable)
+.decl NextInst(prev:Variable, next:Variable)
+
+//LitAssign("c0", "1", "Int").
+Node("c0", "lit:Int").
+NodeArgument("c0", 0, "1").
+//LitAssign("c1", "12", "Int").
+Node("c1", "lit:Int").
+NodeArgument("c1", 0, "12").
+
+
+Node("v1", "CInt").
+NodeArgument("v1", 0, "c0").
+Store("t1", "v1").
+Node("v2", "CInt").
+NodeArgument("v2", 0, "c1").
+Store("t2", "v2").
+Call("v3", "eval").
+CallArgument("v3", 0, "t2").
+NodePattern("p1", "CInt", "v3").
+NodeParameter("p1", 0, "r").
+Call("v4", "_prim_int_print").
+CallArgument("v4", 0, "r").
+
+FunctionParameter("eval", 0, "q").
+Fetch("v", "q").
+Case("h", "v").
+
+Alt("h", "p2", "CInt", "BB0").
+AltParameter("p2", 0, "x").
+AltArgument("p2", 0, "x").
+
+Alt("h", "p3", "#default", "BB1").
+AltParameter("p3", 0, "p3").
+AltArgument("p3", 0, "p3").
+
+BlockParameter("BB0", 0, "y").
+
+ReturnValue("grinMain", "v4").
+ReturnValue("BB0", "v").
+ReturnValue("eval", "h").
+
+FirstInst("grinMain", "c0").
+FirstInst("eval", "v").
+
+NextInst("c0", "c1").
+NextInst("c1", "v1").
+NextInst("v1", "t1").
+NextInst("t1", "v2").
+NextInst("v2", "t2").
+NextInst("t2", "v3").
+NextInst("v3", "p1").
+NextInst("p1", "v4").
+
+NextInst("v", "h").
+
+// Reachability
+.decl ReachableCode(n:CodeName)
+.decl CodeNameInst(n:CodeName, v:Variable)
+
+CodeNameInst(n, v) :-
+  FirstInst(n, v).
+CodeNameInst(n, v) :-
+  CodeNameInst(n, v0),
+  NextInst(v0, v).
+
+.output CodeNameInst(delimiter=",")
+
+ReachableCode("grinMain").
+ReachableCode(n) :-
+  ReachableCode(n0),
+  CodeNameInst(n0, v),
+  Call(v, n).
+
+.output ReachableCode(delimiter=",")
+
+.decl ReachableInst(v:Variable)
+
+ReachableInst(v) :-
+  ReachableCode(n),
+  CodeNameInst(n, v).
+
+// HPT
+/*
+Record(obj, ctx) = hctx
+VarPointsTo(var, ctx, obj, hctx) <-
+  Alloc(var, obj, method),
+  Reachable(method, ctx).
+*/
+.decl VarPointsTo(v:Variable, target:Variable)
+.output VarPointsTo(delimiter=",")
+
+VarPointsTo(v,t) :-
+  Store(v, t),
+  ReachableInst(v).
+
+VarPointsTo(v,t) :-
+  VarPointsTo(v0, t),
+  Move(v, v0),
+  ReachableInst(v).
+
+VarPointsTo(v,t) :-
+  Update(r, v, t),
+  ReachableInst(r).
+
+VarPointsTo(v,t) :-
+  FunctionParameter(_, i, v),
+  CallArgument(r, i, v0),
+  VarPointsTo(v0, t),
+  ReachableInst(r).
+
+///////////////
+
+//.decl Move(result:Variable, value:Variable)
+//.decl LitAssign(result:Variable, l:Literal, lt:LiteralType)
+//.decl Node(result_node:Variable, t:Tag)
+//.decl NodeArgument(result_node:Variable, i:number, item:Variable)
+
+//  .decl Fetch(result:Variable, value:Variable)
+//  .decl Store(result:Variable, value:Variable)
+//  .decl Update(result:Variable, target:Variable, value:Variable)
+
+//.decl Call(call_result:Variable, f:Function)
+//.decl CallArgument(call_result:Variable, i:number, value:Variable)
+//.decl NodePattern(node:Variable, t:Tag, input_value:Variable)
+//.decl NodeParameter(node:Variable, i:number, parameter:Variable)
+//.decl FunctionParameter(f:Function, i:number, parameter:Variable)
+//.decl Case(case_result:Variable, scrutinee:Variable)
+//.decl Alt(case_result:Variable, alt_value:Variable, t:Tag, b:BasicBlock)
+//.decl AltParameter(alt_value:Variable, i:number, parameter:Variable)
+//.decl AltArgument(alt_value:Variable, i:number, value:Variable)
+//.decl BlockParameter(b:BasicBlock, i:number, parameter:Variable)
+//.decl ReturnValue(n:CodeName, value:Variable)
+
+//.decl BlockCall(call_result:Variable, b:BasicBlock) // a.k.a. tail call, jump
+
+///////////////
+
+// Value Computation
+.decl Value(v:Variable, value:Variable)
+.output Value(delimiter=",")
+
+
+// value origin: lit and node
+//Value(v, l) :-
+//  LitAssign(l, _, _),
+//  Move(v, l).
+
+Value(v, n) :-
+  Node(n, _),
+  Move(v, n).
+
+// fun param
+Value(p, val) :-
+  CallArgument(r, i, a),
+  Call(r, f),
+  FunctionParameter(f, i, p),
+  Value(a, val).
+
+// fun return
+Value(r, val) :-
+  Call(r, f),
+  ReturnValue(f, v),
+  Value(v, val).
+
+// bind pattern
+Value(v, val) :-
+  NodePattern(v, tag, n),
+  Value(n, val),
+  Node(val, tag).
+
+Value(param, argval) :-
+  NodePattern(v, tag, n),
+  NodeParameter(v, i, param),
+  Value(n, nval),
+  Node(nval, tag),
+  NodeArgument(nval, i, arg),
+  Value(arg, argval).
+
+
+// case - alt
+
+Value(alt_val, scrut_val) :-
+  Case(case_result, scrut),
+  Alt(case_result, alt_val, tag, bb),
+  Value(scrut, scrut_val),
+  Node(scrut_val, tag).
+
+// alt params
+Value(p, val) :-
+  Alt(_, alt, tag, bb),
+  AltParameter(alt, i, p),
+  Value(alt, node),
+  Node(node, tag),
+  NodeArgument(node, i, narg),
+  Value(narg, val).
+
+// alt bb args
+Value(p, val) :-
+  Alt(_, alt, tag, bb),
+  AltArgument(alt, i, arg),
+  BlockParameter(bb, i, p),
+  Value(arg, val).
+
+// alt result
+Value(case_result, val) :-
+  Case(case_result, _),
+  Alt(case_result, _, _, bb),
+  ReturnValue(bb, v),
+  Value(v, val).
+
+// util: value origins/sources
+Value(n, n) :-
+  Node(n, _).
+
+Value(v, v) :-
+  Store(v, _).
+
+// HPT: store
+Value(v, val) :-
+  Fetch(v, v0),
+  Value(v0, val0),
+  Store(val0, sv),
+  Value(sv, val).
+
+// HPT: update
+Value(v, val) :-
+  Fetch(v, v0),
+  Value(v0, val0),
+  Update(_, val0, sv),
+  Value(sv, val).
+
+/*
+  TODO:
+    case/alt/default pattern
+    context sensitivity
+*/
+
+/*
+grinMain =
+  c0 <- pure 1
+  c1 <- pure 12
+
+  v1 <- pure (CInt c0)
+  t1 <- store v1
+  v2 <- pure (CInt c1)
+  t2 <- store v2
+  v3 <- eval t2
+  p1@(CInt r) <- pure v3
+  v4 <-_prim_int_print r
+  pure v4
+
+eval q = v <- fetch q
+         h <- case v of
+          p2@(CInt x) -> BB0 x
+          p3          -> BB1 p3
+         BB0 y = pure v
+         BB1 y2 = pure y2
+         pure h
+*/

--- a/bb-grin-hpt-2.dl
+++ b/bb-grin-hpt-2.dl
@@ -1,3 +1,6 @@
+#include "new/complex.dl"
+// #include "new/simple.dl"
+
 // heap points-to analysis for grin with basic blocks
 /*
   OLD GRIN PROBLEMS:
@@ -13,30 +16,6 @@
 
   APPROACH:
     define a new AST for the improved GRIN with conversion function to/from the current GRIN AST
-*/
-
-
-/*
-grinMain =
-  c0 <- pure 1
-  c1 <- pure 12
-
-  v1 <- pure (CInt c0)
-  t1 <- store v1
-  v2 <- pure (CInt c1)
-  t2 <- store v2
-  v3 <- eval t2
-  p1@(CInt r) <- pure v3
-  v4 <-_prim_int_print r
-  pure v4
-
-eval q = v <- fetch q
-         h <- case v of
-          p2@(CInt x) -> BB0 x
-          p3          -> BB1 p3
-         BB0 y = pure v
-         BB1 y2 = pure y2
-         pure h
 */
 
 .type BasicBlock
@@ -99,58 +78,6 @@ eval q = v <- fetch q
 .decl FirstInst(n:CodeName, result:Variable)
 .decl NextInst(prev:Variable, next:Variable)
 
-//LitAssign("c0", "1", "Int").
-Node("c0", "lit:Int").
-NodeArgument("c0", 0, "1").
-//LitAssign("c1", "12", "Int").
-Node("c1", "lit:Int").
-NodeArgument("c1", 0, "12").
-
-
-Node("v1", "CInt").
-NodeArgument("v1", 0, "c0").
-Store("t1", "v1").
-Node("v2", "CInt").
-NodeArgument("v2", 0, "c1").
-Store("t2", "v2").
-Call("v3", "eval").
-CallArgument("v3", 0, "t2").
-NodePattern("p1", "CInt", "v3").
-NodeParameter("p1", 0, "r").
-Call("v4", "_prim_int_print").
-CallArgument("v4", 0, "r").
-
-FunctionParameter("eval", 0, "q").
-Fetch("v", "q").
-Case("h", "v").
-
-Alt("h", "p2", "CInt", "BB0").
-AltParameter("p2", 0, "x").
-AltArgument("p2", 0, "x").
-
-Alt("h", "p3", "#default", "BB1").
-AltParameter("p3", 0, "p3").
-AltArgument("p3", 0, "p3").
-
-BlockParameter("BB0", 0, "y").
-
-ReturnValue("grinMain", "v4").
-ReturnValue("BB0", "v").
-ReturnValue("eval", "h").
-
-FirstInst("grinMain", "c0").
-FirstInst("eval", "v").
-
-NextInst("c0", "c1").
-NextInst("c1", "v1").
-NextInst("v1", "t1").
-NextInst("t1", "v2").
-NextInst("v2", "t2").
-NextInst("t2", "v3").
-NextInst("v3", "p1").
-NextInst("p1", "v4").
-
-NextInst("v", "h").
 
 // Reachability
 .decl ReachableCode(n:CodeName)
@@ -262,11 +189,27 @@ Value(r, val) :-
   Value(v, val).
 
 // bind pattern
+// v@(tag ...) <- pure n
+// producer of n is val
+// val <- pure (tag ...)
+// THEN the producer of v is val
 Value(v, val) :-
   NodePattern(v, tag, n),
   Value(n, val),
   Node(val, tag).
 
+// v@(tag ...) <- pure (tag ...)
+// THEN the producer of v is v
+// NOTE: this is already handled by value origins
+// Value(v, v) :-
+//   NodePattern(v, tag, n),
+//   Node(v, tag).
+
+// v@(tag ... param ...) <- pure n
+// producer of n is nval
+// nval <- pure (tag ... arg ...)
+// producer of arg is argval
+// THEN the producer of param is argval
 Value(param, argval) :-
   NodePattern(v, tag, n),
   NodeParameter(v, i, param),
@@ -274,6 +217,17 @@ Value(param, argval) :-
   Node(nval, tag),
   NodeArgument(nval, i, arg),
   Value(arg, argval).
+
+// v@(tag ... param ...) <- pure (tag ... arg ...)
+// producer of arg is argval
+// THEN the producer of param is argval
+// NOTE: already handled by first case
+// Value(param, argval) :-
+//   NodePattern(v, tag, n),
+//   NodeParameter(v, i, param),
+//   Node(v, tag),
+//   Value(arg, argval),
+//   Move(param, arg).
 
 
 // case - alt

--- a/bb-grin-hpt.dl
+++ b/bb-grin-hpt.dl
@@ -1,3 +1,6 @@
+#include "old/complex.dl"
+// #include "old/simple.dl"
+
 // heap points-to analysis for grin with basic blocks
 /*
   OLD GRIN PROBLEMS:
@@ -13,30 +16,6 @@
 
   APPROACH:
     define a new AST for the improved GRIN with conversion function to/from the current GRIN AST
-*/
-
-
-/*
-grinMain =
-  c0 <- pure 1
-  c1 <- pure 12
-
-  v1 <- pure (CInt c0)
-  t1 <- store v1
-  v2 <- pure (CInt c1)
-  t2 <- store v2
-  v3 <- eval t2
-  p1@(CInt r) <- pure v3
-  v4 <-_prim_int_print r
-  pure v4
-
-eval q = v <- fetch q
-         h <- case v of
-          p2@(CInt x) -> BB0 x
-          p3          -> BB1 p3
-         BB0 y = pure v
-         BB1 y2 = pure y2
-         pure h
 */
 
 .type BasicBlock
@@ -98,59 +77,6 @@ eval q = v <- fetch q
 // instruction ordering
 .decl FirstInst(n:CodeName, result:Variable)
 .decl NextInst(prev:Variable, next:Variable)
-
-//LitAssign("c0", "1", "Int").
-Node("c0", "lit:Int").
-NodeArgument("c0", 0, "1").
-//LitAssign("c1", "12", "Int").
-Node("c1", "lit:Int").
-NodeArgument("c1", 0, "12").
-
-
-Node("v1", "CInt").
-NodeArgument("v1", 0, "c0").
-Store("t1", "v1").
-Node("v2", "CInt").
-NodeArgument("v2", 0, "c1").
-Store("t2", "v2").
-Call("v3", "eval").
-CallArgument("v3", 0, "t2").
-NodePattern("p1", "CInt", "v3").
-NodeParameter("p1", 0, "r").
-Call("v4", "_prim_int_print").
-CallArgument("v4", 0, "r").
-
-FunctionParameter("eval", 0, "q").
-Fetch("v", "q").
-Case("h", "v").
-
-Alt("h", "p2", "CInt", "BB0").
-AltParameter("p2", 0, "x").
-AltArgument("p2", 0, "x").
-
-Alt("h", "p3", "#default", "BB1").
-AltParameter("p3", 0, "p3").
-AltArgument("p3", 0, "p3").
-
-BlockParameter("BB0", 0, "y").
-
-ReturnValue("grinMain", "v4").
-ReturnValue("BB0", "v").
-ReturnValue("eval", "h").
-
-FirstInst("grinMain", "c0").
-FirstInst("eval", "v").
-
-NextInst("c0", "c1").
-NextInst("c1", "v1").
-NextInst("v1", "t1").
-NextInst("t1", "v2").
-NextInst("v2", "t2").
-NextInst("t2", "v3").
-NextInst("v3", "p1").
-NextInst("p1", "v4").
-
-NextInst("v", "h").
 
 // Reachability
 .decl ReachableCode(n:CodeName)

--- a/new/complex.dl
+++ b/new/complex.dl
@@ -1,0 +1,104 @@
+/*
+grinMain =
+  c0 <- pure 1
+  c1 <- pure 12
+
+  v1 <- pure (CInt c0)
+  t1 <- store v1
+  v2 <- pure (CInt c1)
+  t2 <- store v2
+  v3 <- eval t2
+  p4@(CInt r1) <- pure v3
+  v4 <-_prim_int_print r1
+
+  c2 <- pure 2
+  p4@(CInt r2) <- pure (CInt c2)
+  t3 <- store p2
+  v5 <- _primt_int_print r2
+  v6 <- eval t3
+
+  pure v4
+
+eval q = v <- fetch q
+         h <- case v of
+          p2@(CInt x) -> BB0 x
+          p3          -> BB1 p3
+         BB0 y = pure v
+         BB1 y2 = pure y2
+         pure h
+*/
+
+//LitAssign("c0", "1", "Int").
+Node("c0", "lit:Int").
+NodeArgument("c0", 0, "1").
+//LitAssign("c1", "12", "Int").
+Node("c1", "lit:Int").
+NodeArgument("c1", 0, "12").
+
+
+Node("v1", "CInt").
+NodeArgument("v1", 0, "c0").
+Store("t1", "v1").
+Node("v2", "CInt").
+NodeArgument("v2", 0, "c1").
+Store("t2", "v2").
+Call("v3", "eval").
+CallArgument("v3", 0, "t2").
+NodePattern("p1", "CInt", "v3").
+NodeParameter("p1", 0, "r1").
+
+Call("v4", "_prim_int_print").
+CallArgument("v4", 0, "r1").
+
+Node("c2", "lit:Int").
+// BEGIN: p4@(CInt r2) <- pure (CInt c2)
+Node("p4", "CInt").
+NodeArgument("p4", 0, "c2").
+NodePattern("p4", "CInt", "p4").
+NodeParameter("p4", 0, "r2").
+Move("r2", "c2"). // is this needed?
+// END
+Store("t3", "p4").
+
+Call("v5", "_prim_int_print").
+CallArgument("v5", 0, "r2").
+Call("v6", "eval").
+CallArgument("v6", 0, "t3").
+
+FunctionParameter("eval", 0, "q").
+Fetch("v", "q").
+Case("h", "v").
+
+Alt("h", "p2", "CInt", "BB0").
+AltParameter("p2", 0, "x").
+AltArgument("p2", 0, "x").
+
+Alt("h", "p3", "#default", "BB1").
+AltParameter("p3", 0, "p3").
+AltArgument("p3", 0, "p3").
+
+BlockParameter("BB0", 0, "y").
+
+ReturnValue("grinMain", "v4").
+ReturnValue("BB0", "v").
+ReturnValue("eval", "h").
+
+FirstInst("grinMain", "c0").
+FirstInst("eval", "v").
+
+NextInst("c0", "c1").
+NextInst("c1", "v1").
+NextInst("v1", "t1").
+NextInst("t1", "v2").
+NextInst("v2", "t2").
+NextInst("t2", "v3").
+NextInst("v3", "p1").
+NextInst("p1", "v4").
+
+NextInst("v4", "c2").
+NextInst("c2", "p4"). // QUESTION: do we need two p4s ?
+NextInst("p4", "t3").
+NextInst("t3", "v5").
+NextInst("v5", "v6").
+
+NextInst("v", "h").

--- a/new/simple.dl
+++ b/new/simple.dl
@@ -1,0 +1,28 @@
+/*
+grinMain =
+  v0 <- pure (CNil)
+  v1 <- pure (CNil)
+  y0 <- f v0
+  y1 <- f v1
+  pure 0
+
+f x =
+  pure x
+*/
+
+Node("v0", "CNil").
+Node("v1", "CNil").
+Call("y0", "f").
+CallArgument("y0", 0, "v0").
+Call("y1", "f").
+CallArgument("y1", 0, "v1").
+
+ReturnValue("grinMain", "lit:Int").
+ReturnValue("f", "x").
+
+FunctionParameter("f", 0, "x").
+
+FirstInst("grinMain", "v0").
+NextInst("v0", "v1").
+NextInst("v1", "y0").
+NextInst("y0", "y1").

--- a/old/complex.dl
+++ b/old/complex.dl
@@ -1,0 +1,98 @@
+/*
+grinMain =
+  c0 <- pure 1
+  c1 <- pure 12
+
+  v1 <- pure (CInt c0)
+  t1 <- store v1
+  v2 <- pure (CInt c1)
+  t2 <- store v2
+  v3 <- eval t2
+  p1@(CInt r) <- pure v3
+  v4 <-_prim_int_print r
+
+  c2 <- pure 2
+  v5 <- pure (CInt c2)
+  p4@(CInt r2) <- pure v5
+  t3 <- store p4
+  v6 <- _primt_int_print r2
+  v7 <- eval t3
+
+  pure v4
+
+eval q = v <- fetch q
+         h <- case v of
+          p2@(CInt x) -> BB0 x
+          p3          -> BB1 p3
+         BB0 y = pure v
+         BB1 y2 = pure y2
+         pure h
+*/
+
+// TODO: NextInst
+
+Node("c0", "lit:Int").
+NodeArgument("c0", 0, "1").
+Node("c1", "lit:Int").
+NodeArgument("c1", 0, "12").
+
+
+Node("v1", "CInt").
+NodeArgument("v1", 0, "c0").
+Store("t1", "v1").
+Node("v2", "CInt").
+NodeArgument("v2", 0, "c1").
+Store("t2", "v2").
+Call("v3", "eval").
+CallArgument("v3", 0, "t2").
+NodePattern("p1", "CInt", "v3").
+NodeParameter("p1", 0, "r").
+Call("v4", "_prim_int_print").
+CallArgument("v4", 0, "r").
+Node("c2", "lit:int").
+Node("v5", "CInt").
+NodePattern("p4", "CInt", "v5").
+NodeParameter("p4", 0, "r2").
+Store("t3", "p4").
+Call("v6", "_prim_int_print").
+CallArgument("v6", 0, "r2").
+Call("v7", "eval").
+CallArgument("v7", 0, "t3").
+
+FunctionParameter("eval", 0, "q").
+Fetch("v", "q").
+Case("h", "v").
+
+Alt("h", "p2", "CInt", "BB0").
+AltParameter("p2", 0, "x").
+AltArgument("p2", 0, "x").
+
+Alt("h", "p3", "#default", "BB1").
+AltParameter("p3", 0, "p3").
+AltArgument("p3", 0, "p3").
+
+BlockParameter("BB0", 0, "y").
+
+ReturnValue("grinMain", "v4").
+ReturnValue("BB0", "v").
+ReturnValue("eval", "h").
+
+FirstInst("grinMain", "c0").
+FirstInst("eval", "v").
+
+NextInst("c0", "c1").
+NextInst("c1", "v1").
+NextInst("v1", "t1").
+NextInst("t1", "v2").
+NextInst("v2", "t2").
+NextInst("t2", "v3").
+NextInst("v3", "p1").
+NextInst("p1", "v4").
+NextInst("v4", "c2").
+NextInst("c2", "v5").
+NextInst("v5", "p4").
+NextInst("p4", "t3").
+NextInst("t3", "v6").
+NextInst("v6", "v7").
+
+NextInst("v", "h").

--- a/old/simple.dl
+++ b/old/simple.dl
@@ -1,0 +1,28 @@
+/*
+grinMain =
+  v0 <- pure (CNil)
+  v1 <- pure (CNil)
+  y0 <- f v0
+  y1 <- f v1
+  pure 0
+
+f x =
+  pure x
+*/
+
+Node("v0", "CNil").
+Node("v1", "CNil").
+Call("y0", "f").
+CallArgument("y0", 0, "v0").
+Call("y1", "f").
+CallArgument("y1", 0, "v1").
+
+ReturnValue("grinMain", "lit:Int").
+ReturnValue("f", "x").
+
+FunctionParameter("f", 0, "x").
+
+FirstInst("grinMain", "v0").
+NextInst("v0", "v1").
+NextInst("v1", "y0").
+NextInst("y0", "y1").


### PR DESCRIPTION
Now bindings with node patterns can have right-hand sides of the form `pure <node>`.